### PR TITLE
Prefer `snap_getBip44Entropy`

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/shapeshift/metamask-snaps.git"
   },
   "source": {
-    "shasum": "Jyqlsxq2jjLuQrK21zPrscgYdK0FTE8YrEk/dORKGmE=",
+    "shasum": "0e7Iy3rhrBh3tvydP0O5Hb6MFMMa+adTK3S/DcxtPLU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -19,14 +19,32 @@
   },
   "initialPermissions": {
     "snap_confirm": {},
-    "snap_getBip44Entropy_0": {},
-    "snap_getBip44Entropy_2": {},
-    "snap_getBip44Entropy_3": {},
-    "snap_getBip44Entropy_60": {},
-    "snap_getBip44Entropy_118": {},
-    "snap_getBip44Entropy_145": {},
-    "snap_getBip44Entropy_714": {},
-    "snap_getBip44Entropy_931": {},
+    "snap_getBip44Entropy": [
+      {
+        "coinType": 0
+      },
+      {
+        "coinType": 2
+      },
+      {
+        "coinType": 3
+      },
+      {
+        "coinType": 60
+      },
+      {
+        "coinType": 118
+      },
+      {
+        "coinType": 145
+      },
+      {
+        "coinType": 714
+      },
+      {
+        "coinType": 913
+      }
+    ],
     "snap_manageState": {},
     "endowment:network-access": {},
     "endowment:long-running": {}

--- a/packages/snap/src/rpc/common.ts
+++ b/packages/snap/src/rpc/common.ts
@@ -32,8 +32,10 @@ export const getHDWalletNativeSigner = async (coinType: string): Promise<NativeH
   }
   // eslint-disable-next-line no-undef
   const node: BIP44CoinTypeNode = (await wallet.request({
-    method: `snap_getBip44Entropy_${chainCode}`,
-    params: [],
+    method: `snap_getBip44Entropy`,
+    params: {
+      coinType: chainCode
+    },
   })) as BIP44CoinTypeNode
   try {
     if (node.privateKey === undefined) {


### PR DESCRIPTION
Uses the new `snap_getBip44Entropy` RPC call instead of the deprecated wildcard implementation.