### PR TITLE
fix: snap ensure proper detection when multiple wallets installed

### DIFF
--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/metamask-snaps-adapter",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "",
   "author": "pastaghost <pastaghost@2520.io> (http://www.github.com/pastaghost)",
   "homepage": "https://github.com/shapeshift/metamask-snaps/tree/main/packages/adapter",
@@ -30,6 +30,7 @@
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/metamask-snaps": "^1.0.10",
     "@shapeshiftoss/metamask-snaps-types": "^1.0.10",
+    "mipd": "^0.0.7",
     "p-queue": "^7.4.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7286,6 +7286,7 @@ __metadata:
     eslint-plugin-prettier: ^5.0.0
     eslint-plugin-react: ^7.33.2
     eslint-plugin-simple-import-sort: ^10.0.0
+    mipd: ^0.0.7
     p-queue: ^7.4.1
     prettier: ^2.8.8
     prettier-package-json: ^2.8.0
@@ -19529,6 +19530,18 @@ __metadata:
     minipass: ^3.0.0
     yallist: ^4.0.0
   checksum: f1fdeac0b07cf8f30fcf12f4b586795b97be856edea22b5e9072707be51fc95d41487faec3f265b42973a304fe3a64acd91a44a3826a963e37b37bafde0212c3
+  languageName: node
+  linkType: hard
+
+"mipd@npm:^0.0.7":
+  version: 0.0.7
+  resolution: "mipd@npm:0.0.7"
+  peerDependencies:
+    typescript: ">=5.0.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 14526f78d6d1bc8580898922508d64714f5abc7293b5998fe93c54237fd1cea120dc98674fe2b329ba3803bda5a85f3e442c3b1fa880e4c6b443bf73018514a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ensures the correct EIP-1193 provider is used using EIP-6963 mipd detection. 

Tested across the board with snaps adapter/hdwallet/web local link and confirmed this makes JSON-RPC requests happy internally within the snap when multiple EIP-1193 wallets are installed:

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/360c4160-78cb-43a5-8fb8-1269da2cade2">